### PR TITLE
購入履歴の関数をまとめる

### DIFF
--- a/www/html/purchase_details.php
+++ b/www/html/purchase_details.php
@@ -27,20 +27,20 @@ if(is_admin($user) === false){
     // 一般ユーザーであればユーザーID紐付けで検索
 // order_idを使って購入明細情報の取得
 $purchase_details = get_purchase_details($db,$user['user_id'],$order_id);
-// order_idを使って購入履歴の注文番号一つのみを取得
-$purchase_detail = get_purchase_detail($db,$user['user_id'],$order_id);
+// user_idを使って購入履歴を取得
+$purchase_history = get_purchase_history($db,$user['user_id']);
 } else {
     // 管理者なら全検索
 // order_idを使って購入明細情報の取得
 $purchase_details = get_purchase_details_admin($db,$order_id);
-// order_idを使って購入履歴の注文番号一つのみを取得
-$purchase_detail = get_purchase_detail_admin($db,$order_id);
+// 購入履歴を取得
+$purchase_history = get_purchase_history_admin($db);
 }
 
-// 二次元配列の特殊文字をHTMLエンティティにする
+// 購入明細の特殊文字をHTMLエンティティにする
 $purchase_details = entity_change($purchase_details);
-// 一次元配列の特殊文字をHTMLエンティティにする
-$purchase_detail = entity_change_one($purchase_detail);
+// 上に表示する購入履歴の特殊文字をHTMLエンティティにする
+$purchase_history = entity_change($purchase_history);
 
 // トークンを取得する
 get_csrf_token();

--- a/www/model/purchase_details.php
+++ b/www/model/purchase_details.php
@@ -47,28 +47,6 @@ function get_purchase_details($db,$user_id,$order_id){
     return fetch_all_query($db, $sql, array($user_id,$order_id));
 }
 
-// 購入履歴を取得(注文番号紐付け)
-function get_purchase_detail($db,$user_id,$order_id){
-  $sql="
-    SELECT 
-      purchase.order_id AS order_id,
-      purchase.createdate AS createdate,
-      SUM(order_details.price * order_details.quantity) AS price
-    FROM
-      purchase
-    INNER JOIN 
-      order_details
-    ON 
-      purchase.order_id = order_details.order_id
-    WHERE
-      user_id = ? AND
-      order_details.order_id = ?
-    GROUP BY
-      order_details.order_id
-  ";
-  return fetch_query($db, $sql, array($user_id,$order_id));
-}
-
 
 /*管理者用検索*/
 
@@ -111,27 +89,6 @@ function get_purchase_details_admin($db,$order_id){
     return fetch_all_query($db, $sql, array($order_id));
 }
 
-
-// 購入履歴を取得(注文番号紐付け) 管理者ならユーザーID指定なし
-function get_purchase_detail_admin($db,$order_id){
-  $sql="
-    SELECT 
-      purchase.order_id AS order_id,
-      purchase.createdate AS createdate,
-      SUM(order_details.price * order_details.quantity) AS price
-    FROM
-      purchase
-    INNER JOIN 
-      order_details
-    ON 
-      purchase.order_id = order_details.order_id
-    WHERE
-      order_details.order_id = ?
-    GROUP BY
-      order_details.order_id
-  ";
-  return fetch_query($db, $sql, array($order_id));
-}
 
 // ランキング表示に使う関数
 function get_items_ranking($db){

--- a/www/view/purchase_details_view.php
+++ b/www/view/purchase_details_view.php
@@ -11,25 +11,30 @@
     <div class="container">
         <h1>購入明細</h1>
         <?php include VIEW_PATH . 'templates/messages.php'; ?>
-        <?php if(count($purchase_detail) > 0){ ?>
-          <table class="table table-bordered text-center">
-              <thead class="thead-light">
-                <tr>
-                  <th>注文番号</th>
-                  <th>購入日時</th>
-                  <th>該当の注文の合計金額</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>  
-                  <td><?php print $purchase_detail['order_id'];?></td>
-                  <td><?php print $purchase_detail['createdate'];?></td>
-                  <td><?php print number_format($purchase_detail['price']).'円';?></td>
-                </tr>
-              </tbody>
-          </table>
+        <?php if(count($purchase_history) > 0){ ?>
+          <?php foreach($purchase_history as $value){ ?>
+            <?php if($value['order_id'] === $order_id){ ?>
+            <table class="table table-bordered text-center">
+                <thead class="thead-light">
+                  <tr>
+                    <th>注文番号</th>
+                    <th>購入日時</th>
+                    <th>該当の注文の合計金額</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>  
+                    <td><?php print $value['order_id'];?></td>
+                    <td><?php print $value['createdate'];?></td>
+                    <td><?php print number_format($value['price']).'円';?></td>
+                  </tr>
+                </tbody>
+            </table>
+            <?php } ?>
+          <?php } ?>
         <?php } else { print '購入履歴はありません';} ?>
         
+
         <?php if(count($purchase_details) > 0){ ?>
           <table class="table table-bordered text-center">
               <thead class="thead-light">


### PR DESCRIPTION
ほぼ同じ内容の関数を消し、変わりに購入履歴画面で使用した関数get_purchase_historyを、購入明細画面で再利用して、foreachで展開し、押された番号のみをif文で限定的に表示するようにしました。

小計と合計を同時に引き出すためにROLLUP句があることを知り、使おうとしましたが何回やっても上手く出来ず、他の方法も模索しましたが上手く繋がらなかったので、最終的に上記の方法を思いつきました。
ご確認お願いします！